### PR TITLE
add libyaml support for speedup

### DIFF
--- a/app.rednotebook.RedNotebook.yaml
+++ b/app.rednotebook.RedNotebook.yaml
@@ -30,6 +30,7 @@ modules:
   - gtksourceview.yaml
   - enchant.yaml
   - python3-pyenchant.yaml
+  - libyaml.yaml
   - python3-PyYAML.yaml
   - RedNotebook.yaml
 cleanup:

--- a/libyaml.yaml
+++ b/libyaml.yaml
@@ -1,0 +1,5 @@
+name: libyaml
+sources:
+  - type: archive
+    url: http://pyyaml.org/download/libyaml/yaml-0.2.1.tar.gz
+    sha256: 78281145641a080fb32d6e7a87b9c0664d611dcb4d542e90baf731f51cbb59cd

--- a/python3-PyYAML.yaml
+++ b/python3-PyYAML.yaml
@@ -5,4 +5,4 @@ sources:
     url: https://files.pythonhosted.org/packages/9e/a3/1d13970c3f36777c583f136c136f804d70f500168edc1edea6daa7200769/PyYAML-3.13.tar.gz
     sha256: 3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf
 build-commands:
-  - pip3 install --no-index --find-links="file://${PWD}" --prefix="${FLATPAK_DEST}" PyYAML
+  - pip3 install --global-option='--with-libyaml' --no-index --find-links="file://${PWD}" --prefix="${FLATPAK_DEST}" PyYAML


### PR DESCRIPTION
Turned out that pyyaml was build without libyaml bindings.
as yaml.h is missing libyaml needs to be included.
Do I miss something?