### PR TITLE
Update bundled pyenchant to version 3.1.1

### DIFF
--- a/python3-pyenchant.yaml
+++ b/python3-pyenchant.yaml
@@ -2,7 +2,7 @@ name: python3-pyenchant
 buildsystem: simple
 sources:
   - type: file
-    url: https://files.pythonhosted.org/packages/9e/54/04d88a59efa33fefb88133ceb638cdf754319030c28aadc5a379d82140ed/pyenchant-2.0.0.tar.gz
-    sha256: fc31cda72ace001da8fe5d42f11c26e514a91fa8c70468739216ddd8de64e2a0
+    url: https://files.pythonhosted.org/packages/d8/43/87ddf3feb92de8464d082f3fc80541bcff6c5b54ef286ff5ef70db7c8da7/pyenchant-3.1.1.tar.gz
+    sha256: ce0915d7acd771fde6e8c2dce8ad0cb0e6f7c4fa8430cc96e3e7134e99aeb12f
 build-commands:
   - pip3 install --no-index --find-links="file://${PWD}" --prefix="${FLATPAK_DEST}" pyenchant


### PR DESCRIPTION
This fixes #5 (at least for me on Fedora 32).

It [looks like](https://pypi.org/project/pyenchant/#history) pyenchant releases stopped for a couple of years after 2017, and then resumed earlier this year.