### PR TITLE
Update Gnome runtime to 3.36

### DIFF
--- a/app.rednotebook.RedNotebook.yaml
+++ b/app.rednotebook.RedNotebook.yaml
@@ -1,6 +1,6 @@
 app-id: app.rednotebook.RedNotebook
 runtime: org.gnome.Platform
-runtime-version: '3.34'
+runtime-version: '3.36'
 sdk: org.gnome.Sdk
 command: rednotebook
 rename-appdata-file: rednotebook.appdata.xml


### PR DESCRIPTION
No idea whether this will work this easily, but Flatpak has started issuing warnings that:

> The GNOME 3.34 runtime is no longer supported as of 14th August 2020. Please ask your application developer to migrate to a supported platform.