### PR TITLE
Change to standard permissions to disallow DRI access.

### DIFF
--- a/app.rednotebook.RedNotebook.yaml
+++ b/app.rednotebook.RedNotebook.yaml
@@ -22,7 +22,7 @@ finish-args:
   # to access remote images
   - --share=network
   # OpenGL access
-  - --device=dri
+  #- --device=dri # removed due to upstream GPU rendering bug for HTML views.
 modules:
   - gtksourceview.yaml
   - enchant.yaml


### PR DESCRIPTION
Fixes #727  by disabling GPU DRI access by default.