### PR TITLE
Update RedNotebook runtime to 46

### DIFF
--- a/app.rednotebook.RedNotebook.yaml
+++ b/app.rednotebook.RedNotebook.yaml
@@ -1,6 +1,6 @@
 app-id: app.rednotebook.RedNotebook
 runtime: org.gnome.Platform
-runtime-version: '44'
+runtime-version: '46'
 sdk: org.gnome.Sdk
 command: rednotebook
 rename-appdata-file: rednotebook.appdata.xml


### PR DESCRIPTION
- Update RedNotebook runtime to 46 since runtime version 44 has reached end-of-life.